### PR TITLE
add 'board.changes' and 'board.cards' methods

### DIFF
--- a/src/api/board.js
+++ b/src/api/board.js
@@ -15,6 +15,34 @@ module.exports = ( api, request ) => {
 		} );
 	};
 
+	api.board.changes = ( boardId, version ) => {
+		return request( {
+			url: `/io/board/${ boardId }/changes?version=${ version }`,
+			method: "get"
+		} );
+	};
+
+	api.board.cards = ( { boardId, cards, lanes} ) => {
+		let qs = "";
+		if( cards ){
+			if( typeof( cards ) === "object" ) {
+				cards = cards.join();
+			}
+			qs+= `cards=${ cards }&`;
+		}
+		if( lanes ) {
+			if( typeof( lanes ) === "object" ) {
+				lanes = lanes.join();
+			}
+			qs+= `lanes=${ lanes }`;
+		}
+		return request( {
+			url: `/io/board/${ boardId }/card?${ qs }`,
+			method: "get"
+		} );
+	};
+
+
 	api.board.customFields.list = boardId => {
 		return request( {
 			url: `/io/board/${ boardId }/customfield`,


### PR DESCRIPTION
@reverentgeek we should probably discuss this. I believe these two endpoints are not yet published. I think we should publish them and include them here. I added them because I'm using them for a bot we are working on. However, if there is resistance to that, we could add a way to provide a custom url. For the moment we are pointing `leankit-client` to this branch on my fork.

Also, I need to update the readme if we decide to include these.